### PR TITLE
setup.py - added classifiers, markdown for readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,25 +4,33 @@ except:
     from distutils.core import setup
 import os
 
-long_description = "Please visit https://github.com/TyberiusPrime/pyggplot for full description"
-if os.path.exists('README.txt'):
-    with open('README.txt') as op:
-        long_description = op.read()
-
 setup(
     name='pyggplot',
     version='16',
     packages=['pyggplot',],
     license='BSD',
-    #url='http://code.google.com/p/pydataframe/',
+    url='https://github.com/TyberiusPrime/pyggplot',
     author='Florian Finkernagel',
-    description = "A pythonic wrapper around R's ggplot",
+    description = "A Pythonic wrapper around R's ggplot",
     author_email='finkernagel@coonabibba.de',
-    long_description=open('README.txt').read(),
-    package_data={'pyggplot': ['LICENSE.txt', 'README.txt']},
-    include_package_data=True,    install_requires=[
+    long_description=open("README.md").read(),
+    package_data={'pyggplot': ['LICENSE.txt', 'README.md']},
+    include_package_data=True,
+    install_requires=[
         'pandas>=0.15',
         'rpy2',
         'ordereddict',
-        ]
+        ],
+    classifiers=['Development Status :: 3 - Alpha',
+                 'Intended Audience :: Science/Research',
+                 'Topic :: Scientific/Engineering',
+                 'Topic :: Scientific/Engineering :: Visualization',
+                 'Operating System :: Microsoft :: Windows',
+                 'Operating System :: Unix',
+                 'Operating System :: MacOS',
+                 'Programming Language :: Python',
+                 'Programming Language :: Python :: 2',
+                 'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3',
+                 'Programming Language :: Python :: 3.4'],
 )


### PR DESCRIPTION
I have changed a few things in setup, especially - added classifiers.

When it comes to version - increasing by one is unconventional. Shouldn't it be something like `0.5.16` and changing only the last number? Unless there is  big change (breaking API, like name changes, or new features) and then the middle number goes? 
